### PR TITLE
feat(docker): mount models folder as a volume

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -20,6 +20,7 @@ services:
       - /tmp
     volumes:
       - /tmp/.X11-unix:/tmp/.X11-unix
+      - ./models:/app/models
       - ./dataset:/dataset
       - ./dataset/images:/app/data
       - ./dataset/logs:/app/logs


### PR DESCRIPTION
Right now docker-compose creates a copy of the `models` folder inside a container which is inefficient as the folder could reach tens or even hundreds of GBs. 

This PR mounts the `models` folder as a volume similar to the `dataset` and `.cache` folders, thus optimizing startup speed and disk consumption.